### PR TITLE
Add additional upload progress feedback

### DIFF
--- a/assets/multiupload.publish.js
+++ b/assets/multiupload.publish.js
@@ -3,6 +3,7 @@
 	Symphony.Language.add({
 		'Drop files': false,
 		'In queue': false,
+		'Uploading': false,
 		'Remove file': false,
 		'Upload failed': false
 	});
@@ -119,10 +120,16 @@
 				},
 
 				// Upload progress
-				xhrFields: {
-					onprogress: function(progress) {
+				xhr: function() {
+					// get the native XmlHttpRequest object
+					var xhr = $.ajaxSettings.xhr();
+					// set the onprogress event handler
+					xhr.upload.onprogress = function(progress) {
+						item.find('.destructor').text(Symphony.Language.get('Uploading'));
 						item.find('.multiupload-progress').css('width', Math.floor(100 * progress.loaded / progress.total) + '%');
-        			}
+					};
+					// return the customized object
+					return xhr;
 				}
 			});
 		};


### PR DESCRIPTION
Hi Brendan, the progress indicator didn't seem to work for me (at least in Safari 8). This quick change gives me progress bar updates as the files upload.